### PR TITLE
Disable the button on click to prevent double-submits, then re-enable the button if verification was not successful.

### DIFF
--- a/ButtonCode.js
+++ b/ButtonCode.js
@@ -4,6 +4,10 @@ if (interaction.isButton()) {
     if (interaction.customId === 'Global_Verify_Button')
     {
         await interaction.deferUpdate({ephemeral: true })
+        const row = new Discord.ActionRowBuilder()
+                .addComponents(new ButtonBuilder().setCustomId('Global_Verify_Button').setLabel('Verify').setStyle('Secondary').setDisabled(true));
+        await interaction.editReply({ components: [row] });
+        
         const embed = interaction.message.embeds[0]
         const allyCode = embed.title.replace(/\D/g, "")
         const comlinkPayload = {'discordId':interaction.user.id, "method":"verification", "payload": {"allyCode": String(allyCode)}, "enums": false}
@@ -23,14 +27,16 @@ if (interaction.isButton()) {
 
         const comlinkJSON = await comlinkResponse.json()
         if(comlinkJSON == 'verified')
-        {   
-            const row = new Discord.ActionRowBuilder()
-                .addComponents(new ButtonBuilder().setCustomId('Global_Verify_Button').setLabel('Verify').setStyle('Primary').setDisabled(true));
-            await interaction.editReply({ components: [row] })
+        {
             await interaction.followUp({ content: 'You have been sucessfully verified!', ephemeral: true });
         }
         else
+        {
+            const row = new Discord.ActionRowBuilder()
+                .addComponents(new ButtonBuilder().setCustomId('Global_Verify_Button').setLabel('Verify').setStyle('Primary').setDisabled(false));
+            await interaction.editReply({ components: [row] });
             await interaction.followUp({ content: 'Unable to verify. Please double check you have set the correct title & portrait & then "
             + "click verify again.', ephemeral: true });
+        }
     }
 }

--- a/ButtonCode.js
+++ b/ButtonCode.js
@@ -4,9 +4,9 @@ if (interaction.isButton()) {
     if (interaction.customId === 'Global_Verify_Button')
     {
         await interaction.deferUpdate({ephemeral: true })
-        const row = new Discord.ActionRowBuilder()
+        const disabledButtonRow = new Discord.ActionRowBuilder()
                 .addComponents(new ButtonBuilder().setCustomId('Global_Verify_Button').setLabel('Verify').setStyle('Secondary').setDisabled(true));
-        await interaction.editReply({ components: [row] });
+        await interaction.editReply({ components: [disabledButtonRow] });
         
         const embed = interaction.message.embeds[0]
         const allyCode = embed.title.replace(/\D/g, "")
@@ -32,9 +32,9 @@ if (interaction.isButton()) {
         }
         else
         {
-            const row = new Discord.ActionRowBuilder()
+            const enabledButtonRow = new Discord.ActionRowBuilder()
                 .addComponents(new ButtonBuilder().setCustomId('Global_Verify_Button').setLabel('Verify').setStyle('Primary').setDisabled(false));
-            await interaction.editReply({ components: [row] });
+            await interaction.editReply({ components: [enabledButtonRow] });
             await interaction.followUp({ content: 'Unable to verify. Please double check you have set the correct title & portrait & then "
             + "click verify again.', ephemeral: true });
         }


### PR DESCRIPTION
The immediate disable on the button helps prevent double-submits by the user.